### PR TITLE
WIP: Feat: translated text

### DIFF
--- a/src/GraphManager/Header/LocaleManager.tsx
+++ b/src/GraphManager/Header/LocaleManager.tsx
@@ -1,98 +1,38 @@
-import React, { ReactNode, useState } from "react";
-import Button from "@mui/material/Button";
-import TranslateIcon from "@mui/icons-material/Translate";
-import Menu from "@mui/material/Menu";
-import MenuItem from "@mui/material/MenuItem";
-import ListItemText from "@mui/material/ListItemText";
-import useMediaQuery from "@mui/material/useMediaQuery";
-import { useTheme } from "@mui/material";
-import i18n from "@src/shared/i18n";
-
 import { useUserDataContext } from "@src/Context/UserDataContext";
+import { LanguageSelect } from "../LanguageSelect";
+import { ButtonProps, useMediaQuery, useTheme } from "@mui/material";
+import TranslateIcon from "@mui/icons-material/Translate";
 
-interface LanguageDictEntry {
-  displayText: string;
-  displayIcon: ReactNode;
-  localeString: string;
-}
-const languageDict: { [language: string]: LanguageDictEntry } = {
-  en: {
-    displayText: "English",
-    displayIcon: "🇬🇧",
-    localeString: "enUS",
-  },
-  de: {
-    displayText: "Deutsch",
-    displayIcon: "🇩🇪",
-    localeString: "deDE",
-  },
-  zh: {
-    displayText: "中文",
-    displayIcon: "🇹🇼",
-    localeString: "zhTW",
-  },
-};
+import i18n from "@src/shared/i18n";
 
 export default function LocaleManager() {
   const { language, setLanguage } = useUserDataContext();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = (menuItem: string) => {
-    setAnchorEl(null);
-    if (!menuItem) {
-      return;
-    }
-    if (menuItem !== language) {
-      setLanguage(menuItem);
-    }
-  };
 
   const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const buttonText = isSmallScreen
+    ? i18n.t("switch-language-button-short")
+    : i18n.t("switch-language-button");
+
+  const buttonProps: ButtonProps = {
+    variant: "contained",
+    startIcon: <TranslateIcon />,
+    sx: {
+      maxWidth: isSmallScreen ? "100%" : "auto", // Set maximum width for small screens
+      whiteSpace: "normal", // Allow text to wrap
+      textOverflow: "ellipsis", // Add ellipsis if text overflows
+      overflow: "hidden", // Hide overflowed content
+    },
+  };
+
   return (
-    <>
-      <Button
-        variant="contained"
-        startIcon={<TranslateIcon />}
-        onClick={handleClick}
-        aria-label="switch language"
-        sx={{
-          maxWidth: isSmallScreen ? "100%" : "auto", // Set maximum width for small screens
-          whiteSpace: "normal", // Allow text to wrap
-          textOverflow: "ellipsis", // Add ellipsis if text overflows
-          overflow: "hidden", // Hide overflowed content
-        }}
-      >
-        {isSmallScreen
-          ? i18n.t("switch-language-button-short")
-          : i18n.t("switch-language-button")}
-      </Button>
-      <Menu
-        anchorEl={anchorEl}
-        open={open}
-        onClose={() => setAnchorEl(null)}
-        MenuListProps={{
-          "aria-labelledby": "switch language",
-        }}
-      >
-        {Object.entries(languageDict).map(
-          ([languageString, languageProperties]) => {
-            return (
-              <MenuItem
-                onClick={() => handleClose(languageString)}
-                key={languageString}
-              >
-                <ListItemText>{`${languageProperties.displayIcon} ${languageProperties.displayText}`}</ListItemText>
-              </MenuItem>
-            );
-          },
-        )}
-      </Menu>
-    </>
+    <LanguageSelect
+      buttonProps={buttonProps}
+      buttonText={buttonText}
+      selectedLanguage={language}
+      onLanguageSelect={setLanguage}
+    />
   );
 }

--- a/src/GraphManager/LanguageSelect.tsx
+++ b/src/GraphManager/LanguageSelect.tsx
@@ -1,0 +1,70 @@
+import { ListItemText, Menu, MenuItem } from "@mui/material";
+import { languageDict } from "@src/shared/languageDict";
+
+import Button, { ButtonProps } from "@mui/material/Button";
+import { useState } from "react";
+import i18n from "@src/shared/i18n";
+
+interface LanguageSelectProps {
+  onLanguageSelect: (arg0: string) => void;
+  selectedLanguage: string;
+  buttonProps: ButtonProps;
+  buttonText: string;
+}
+
+export const LanguageSelect = ({
+  buttonProps,
+  buttonText,
+  selectedLanguage,
+  onLanguageSelect,
+}: LanguageSelectProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const isOpen = Boolean(anchorEl);
+
+  const handleItemSelect = (languageString: string) => {
+    setAnchorEl(null);
+    if (!languageString) {
+      return;
+    }
+    if (languageString !== selectedLanguage) {
+      onLanguageSelect(languageString);
+    }
+  };
+
+  const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <>
+      <Button
+        {...buttonProps}
+        onClick={handleButtonClick}
+        aria-label="switch language"
+      >
+        {buttonText}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={() => setAnchorEl(null)}
+        MenuListProps={{
+          "aria-labelledby": "switch language",
+        }}
+      >
+        {Object.entries(languageDict).map(
+          ([languageString, languageProperties]) => {
+            return (
+              <MenuItem
+                onClick={() => handleItemSelect(languageString)}
+                key={languageString}
+              >
+                <ListItemText>{`${languageProperties.displayIcon} ${languageProperties.displayText}`}</ListItemText>
+              </MenuItem>
+            );
+          },
+        )}
+      </Menu>
+    </>
+  );
+};

--- a/src/GraphManager/LanguageSelect.tsx
+++ b/src/GraphManager/LanguageSelect.tsx
@@ -2,14 +2,14 @@ import { ListItemText, Menu, MenuItem } from "@mui/material";
 import { languageDict } from "@src/shared/languageDict";
 
 import Button, { ButtonProps } from "@mui/material/Button";
-import { useState } from "react";
-import i18n from "@src/shared/i18n";
+import { ReactNode, useState } from "react";
 
 interface LanguageSelectProps {
   onLanguageSelect: (arg0: string) => void;
   selectedLanguage: string;
   buttonProps: ButtonProps;
-  buttonText: string;
+  buttonText: ReactNode;
+  languageTextMap?: Map<string, string>;
 }
 
 export const LanguageSelect = ({
@@ -17,9 +17,11 @@ export const LanguageSelect = ({
   buttonText,
   selectedLanguage,
   onLanguageSelect,
+  languageTextMap,
 }: LanguageSelectProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const isOpen = Boolean(anchorEl);
+  const hasLanguageTextMap = Boolean(languageTextMap);
 
   const handleItemSelect = (languageString: string) => {
     setAnchorEl(null);
@@ -54,12 +56,25 @@ export const LanguageSelect = ({
       >
         {Object.entries(languageDict).map(
           ([languageString, languageProperties]) => {
+            let displayItem = <></>;
+            if (hasLanguageTextMap) {
+              displayItem = (
+                <ListItemText
+                  title={languageProperties.displayText}
+                >{`${languageProperties.displayIcon} ${languageTextMap?.get(languageString) ?? "-"}`}</ListItemText>
+              );
+            } else {
+              displayItem = (
+                <ListItemText>{`${languageProperties.displayIcon} ${languageProperties.displayText}`}</ListItemText>
+              );
+            }
+
             return (
               <MenuItem
                 onClick={() => handleItemSelect(languageString)}
                 key={languageString}
               >
-                <ListItemText>{`${languageProperties.displayIcon} ${languageProperties.displayText}`}</ListItemText>
+                {displayItem}
               </MenuItem>
             );
           },

--- a/src/LandingPage/Hero.tsx
+++ b/src/LandingPage/Hero.tsx
@@ -51,7 +51,12 @@ export default function Hero() {
         color: theme.palette.text.secondary,
       })}
     >
-      <TranslatedText />
+      <TranslatedText
+        onUpdate={() => {}}
+        inputText={{
+          translations: [{ language: "en", content: "im an eng text" }],
+        }}
+      />
       <Container
         sx={{
           display: "flex",

--- a/src/LandingPage/Hero.tsx
+++ b/src/LandingPage/Hero.tsx
@@ -7,7 +7,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { TranslatedText } from "@src/shared/TranslatedText";
+import { TranslatedText, TranslatedTextStandalone } from "@src/shared/TranslatedText";
 
 export default function Hero() {
   const { t } = useTranslation();
@@ -51,9 +51,9 @@ export default function Hero() {
         color: theme.palette.text.secondary,
       })}
     >
-      <TranslatedText
-        onUpdate={() => {}}
-        inputText={{
+      <TranslatedTextStandalone
+        onSubmit={() => {}}
+        text={{
           translations: [{ language: "en", content: "im an eng text" }],
         }}
       />

--- a/src/LandingPage/Hero.tsx
+++ b/src/LandingPage/Hero.tsx
@@ -7,12 +7,24 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { TranslatedText, TranslatedTextStandalone } from "@src/shared/TranslatedText";
+import {
+  TranslatedText,
+  TranslatedTextStandalone,
+} from "@src/shared/TranslatedText";
 
 export default function Hero() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const theme = useTheme();
+
+  // TODO: mock, delete me
+  function delayedSuccess(): Promise<string> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve("success");
+      }, 2000);
+    });
+  }
 
   const headerText = (
     <Typography
@@ -52,7 +64,7 @@ export default function Hero() {
       })}
     >
       <TranslatedTextStandalone
-        onSubmit={() => {}}
+        onSubmit={delayedSuccess}
         text={{
           translations: [{ language: "en", content: "im an eng text" }],
         }}

--- a/src/LandingPage/Hero.tsx
+++ b/src/LandingPage/Hero.tsx
@@ -7,6 +7,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Trans, useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { TranslatedText } from "@src/shared/TranslatedText";
 
 export default function Hero() {
   const { t } = useTranslation();
@@ -50,6 +51,7 @@ export default function Hero() {
         color: theme.palette.text.secondary,
       })}
     >
+      <TranslatedText />
       <Container
         sx={{
           display: "flex",

--- a/src/shared/TranslatedText.tsx
+++ b/src/shared/TranslatedText.tsx
@@ -3,25 +3,109 @@ import { LanguageSelect } from "@src/GraphManager/LanguageSelect";
 import { useUserDataContext } from "@src/Context/UserDataContext";
 import { languageDict } from "./languageDict";
 import { Text } from "@src/GraphManager/RPCHooks/types";
+import { TextField } from "@mui/material";
+import { Formik, FormikValues } from "formik";
 
-interface TranslatedTextInput {
-  onUpdate: (text: Text) => void;
+interface TranslatedTextInput{
+  onChange: (newValue: string) => void;
   inputText: Text;
+  displayValue: string;
+  onSubmit?: () => void; // if used as standalone, not within a form
+  isSubmitting?: boolean;
+  isEnabled?: boolean;
+  selectedLanguage: string;
+  onLanguageSelect: (arg0: string) => void
 }
 
-export const TranslatedText = ({
-  onUpdate,
-  inputText,
-}: TranslatedTextInput) => {
-  const { language } = useUserDataContext();
+interface StandaloneInput {
+  text: Text
+  onSubmit: (arg0: Text) => void
+}
 
-  const [selectedLanguage, setSelectedLanguage] = useState(language);
+interface FormikInput {
+  formik: ReturnType<typeof Formik<T>>
+  fieldName: keyof T;
+  
+}
+
+const getTranslation = (text: Text, language: string): string => {
+  return text.translations.find(({language: itemLanguage}) => language=== itemLanguage)?.content ?? ''
+}
+
+export const TranslatedTextStandalone = ({onSubmit, text}: StandaloneInput) => {
+  const { language: UILanguage } = useUserDataContext();
+
+  const [selectedLanguage, setSelectedLanguage] = useState(UILanguage);
+  const [displayedText, setDisplayedText] = useState(getTranslation(text, UILanguage))
+
+  const handleLanguageChange = (languageString: string) => {
+    setSelectedLanguage(languageString)
+    setDisplayedText(getTranslation(text, languageString))
+  }
+
+  return (<TranslatedText
+    inputText={text}
+    displayValue={displayedText}
+    onChange={setDisplayedText} 
+    selectedLanguage={selectedLanguage}
+    onLanguageSelect={handleLanguageChange}
+  />)
+
+}
+
+// const TranslatedTextFormik = ({ formik, fieldName, }: FormikInput) => {
+//   const { language: UILanguage } = useUserDataContext();
+
+//   const [selectedLanguage, setSelectedLanguage] = useState(UILanguage);
+
+
+//   const fieldValue = formik.values[fieldName]
+//   const displayValue = fieldValue.translations.find(({language}) => language === UILanguage)?.content ?? ''
+
+
+//   return (
+//     <TranslatedText
+//     displayValue={displayValue}
+//     inputText={fieldValue}
+//     selectedLanguage={selectedLanguage}
+//     setSelectedLanguage={setSelectedLanguage}
+
+//     />
+//   )
+// }
+
+export const TranslatedText = ({
+  inputText,
+  displayValue,
+  onChange,
+  onSubmit,
+  isSubmitting,
+  isEnabled,
+  selectedLanguage,
+  onLanguageSelect,
+
+}: TranslatedTextInput) => {
+  const placeholderText = `🇺🇸 ${getTranslation(inputText, 'en')}`
+
+
   const languageTextMap = new Map();
   inputText.translations.forEach(({ language, content }) =>
-    languageTextMap.set(language, content),
+    {
+      languageTextMap.set(language, content)
+    }
   );
-  //TODO: remove, is just demo
-  languageTextMap.set("de", "deitscher text");
+
+  const hasInputChanged = displayValue !== inputText.translations[selectedLanguage]
+
+  const handleLanguageChange = (languageString: string) => {
+    if (hasInputChanged){
+      // prompt confirm to drop changes, only then change
+    }
+    onLanguageSelect(languageString)
+  } 
+
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value) 
+
 
   return (
     <>
@@ -29,8 +113,14 @@ export const TranslatedText = ({
         buttonText={languageDict[selectedLanguage].displayIcon}
         buttonProps={{ variant: "outlined" }}
         selectedLanguage={selectedLanguage}
-        onLanguageSelect={setSelectedLanguage}
+        onLanguageSelect={handleLanguageChange}
         languageTextMap={languageTextMap}
+      />
+      <TextField
+        fullWidth
+        value={displayValue}
+        onChange={handleTextChange}
+        placeholder={placeholderText}
       />
     </>
   );

--- a/src/shared/TranslatedText.tsx
+++ b/src/shared/TranslatedText.tsx
@@ -1,19 +1,36 @@
-import { Autocomplete, Box } from "@mui/material";
 import { useState } from "react";
 import { LanguageSelect } from "@src/GraphManager/LanguageSelect";
 import { useUserDataContext } from "@src/Context/UserDataContext";
+import { languageDict } from "./languageDict";
+import { Text } from "@src/GraphManager/RPCHooks/types";
 
-export const TranslatedText = () => {
+interface TranslatedTextInput {
+  onUpdate: (text: Text) => void;
+  inputText: Text;
+}
+
+export const TranslatedText = ({
+  onUpdate,
+  inputText,
+}: TranslatedTextInput) => {
   const { language } = useUserDataContext();
 
   const [selectedLanguage, setSelectedLanguage] = useState(language);
+  const languageTextMap = new Map();
+  inputText.translations.forEach(({ language, content }) =>
+    languageTextMap.set(language, content),
+  );
+  //TODO: remove, is just demo
+  languageTextMap.set("de", "deitscher text");
+
   return (
     <>
       <LanguageSelect
-        buttonText="whee"
-        buttonProps={{}}
+        buttonText={languageDict[selectedLanguage].displayIcon}
+        buttonProps={{ variant: "outlined" }}
         selectedLanguage={selectedLanguage}
         onLanguageSelect={setSelectedLanguage}
+        languageTextMap={languageTextMap}
       />
     </>
   );

--- a/src/shared/TranslatedText.tsx
+++ b/src/shared/TranslatedText.tsx
@@ -1,0 +1,20 @@
+import { Autocomplete, Box } from "@mui/material";
+import { useState } from "react";
+import { LanguageSelect } from "@src/GraphManager/LanguageSelect";
+import { useUserDataContext } from "@src/Context/UserDataContext";
+
+export const TranslatedText = () => {
+  const { language } = useUserDataContext();
+
+  const [selectedLanguage, setSelectedLanguage] = useState(language);
+  return (
+    <>
+      <LanguageSelect
+        buttonText="whee"
+        buttonProps={{}}
+        selectedLanguage={selectedLanguage}
+        onLanguageSelect={setSelectedLanguage}
+      />
+    </>
+  );
+};

--- a/src/shared/languageDict.tsx
+++ b/src/shared/languageDict.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+
+export interface LanguageDictEntry {
+  displayText: string;
+  displayIcon: ReactNode;
+  localeString: string;
+}
+
+export const languageDict: { [language: string]: LanguageDictEntry } = {
+  en: {
+    displayText: "English",
+    displayIcon: "🇬🇧",
+    localeString: "enUS",
+  },
+  de: {
+    displayText: "Deutsch",
+    displayIcon: "🇩🇪",
+    localeString: "deDE",
+  },
+  zh: {
+    displayText: "中文",
+    displayIcon: "🇹🇼",
+    localeString: "zhTW",
+  },
+};


### PR DESCRIPTION
TranslatableText Component
it
should have a menu to select the language
the menu should display all translations when it is open
it should have buttons to save changes or reset them
it should have an unchanged state (buttons disabled, but always there for accessibility)
it should have a changed state (buttons enabled)
it should have a submitting state
it should report changes by the configured definition (onChange, onBlur, ...)
it should replace the content when switching language, also reset the changed state
it should promt for discarding when switching language with unsaved changes
when selecting an empty language, it should display fallbacks to other languages, as en > any other language, or userprofile preferences?
it should display a submitting state
it should display an error state and helper text
when submitting changes, the button should switch to a loading state
whenthe submission succeeds, the success should be displayed (how?), and the component should return to the default unchanged state
when submission fails, the error should be displayed


wrapper component:
states/vars:
- current value
- original value
- => submitActive (computed)
- current language
- isSubmitting
- error
- display error?
- fallback language value (computed)
validation rules as props for form/validation lib?
- onChange
- onLanguageChange
- onSubmit
- onReset
