### PR TITLE
fix: markdown issue for url with curly braces inside

### DIFF
--- a/src/GraphManager/GraphEdit/MarkdownField.test.tsx
+++ b/src/GraphManager/GraphEdit/MarkdownField.test.tsx
@@ -1,5 +1,18 @@
+import { validateUrl } from "./MarkdownField";
+
+// must mock this, since it's incompatible with create-react-app's jest config (see PopUp.test.tsx)
+jest.mock("@mui/material/OutlinedInput/NotchedOutline", () => (props: any) => {
+  return <div>props: {JSON.stringify(props)}</div>;
+});
+
+
 describe("validateUrl", () => {
   it("should match an ugly url with ()-braces!", () => {
-    expect(1).toBe(1);
-  })
-})
+    expect(
+      validateUrl("https://de.wikipedia.org/wiki/Gruppe_(Mathematik)")
+    ).toBe(true);
+  });
+  // it("should not validate a link that is just https://", () => {
+  //   expect(validateUrl("https://")).toBe(false);
+  // })
+});

--- a/src/GraphManager/GraphEdit/MarkdownField.test.tsx
+++ b/src/GraphManager/GraphEdit/MarkdownField.test.tsx
@@ -1,0 +1,5 @@
+describe("validateUrl", () => {
+  it("should match an ugly url with ()-braces!", () => {
+    expect(1).toBe(1);
+  })
+})

--- a/src/GraphManager/GraphEdit/MarkdownField.tsx
+++ b/src/GraphManager/GraphEdit/MarkdownField.tsx
@@ -42,7 +42,13 @@ const urlRegExp = new RegExp(
 );
 export const validateUrl = (url: string): boolean => {
   return url === "https://" || urlRegExp.test(url);
+  //          ^-- this one confuses me the urlRegExp should be 
+  //              enough to find all valid links...
 };
+
+// const containsUrl = (markdown: string): boolean => {
+//   return 
+// };
 
 export interface MarkdownConfig {
   fieldName: string;

--- a/src/GraphManager/GraphEdit/MarkdownField.tsx
+++ b/src/GraphManager/GraphEdit/MarkdownField.tsx
@@ -40,7 +40,7 @@ import { useTheme } from "@emotion/react";
 const urlRegExp = new RegExp(
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w]*))?)/,
 );
-const validateUrl = (url: string): boolean => {
+export const validateUrl = (url: string): boolean => {
   return url === "https://" || urlRegExp.test(url);
 };
 
@@ -119,6 +119,13 @@ const MarkdownEditor = (props: MarkdownEditorConfig) => {
     editorState.read(() => {
       markdown = $convertToMarkdownString(TRANSFORMERS_MARKDOWN);
     });
+    // TODO:
+    //if containsUrl(markdown) {
+    //  markdown = fixLinkIssue(markdown);
+    //}
+    // 1) http://localhost:3000/graph <- has ()-braces? no
+    // 2) [http://localhost:3000/grap(h)](http://localhost:3000/grap%27h%28)
+    // 3) http://localhost:3000/grap(h) <- has braces must be changed
     props.setValueOnChange(markdown);
     props.setIsEmpty(markdown === "");
   };


### PR DESCRIPTION
Example: This will not be rendered correctly in the markdown editor as link, but it will show as string and not be clickable.
```
[https://de.wikipedia.org/wiki/Feld_(Physik)](https://de.wikipedia.org/wiki/Feld_(Physik))
```
Solution: rewrite (,) as %27, %28 hex values.