### PR TITLE
fix: remove red shadow from links

### DIFF
--- a/src/GraphManager/utils.ts
+++ b/src/GraphManager/utils.ts
@@ -386,8 +386,8 @@ export const linkPointerAreaPaint = (
 
 export const drawLinkLine = (conf: DrawLinkConfig) => {
   const { ctx, color, link } = conf;
-  ctx.shadowBlur = 20;
-  ctx.shadowColor = "#FD0100";
+  //ctx.shadowBlur = 20;
+  //ctx.shadowColor = "#FD0100";
   ctx.strokeStyle = color;
   ctx.fillStyle = color;
   let scale = conf.globalScale;


### PR DESCRIPTION
It's too performance intense. Pretty design must come after changes in the architecture from graph-rendering to a land-map.